### PR TITLE
Javascript-Based Select "Deluxe"

### DIFF
--- a/package.js
+++ b/package.js
@@ -51,6 +51,8 @@ Package.onUse(function(api) {
     'templates/semantic-ui/inputTypes/select/select.js',
     'templates/semantic-ui/inputTypes/select-checkbox/select-checkbox.html',
     'templates/semantic-ui/inputTypes/select-checkbox/select-checkbox.js',
+    'templates/semantic-ui/inputTypes/select-deluxe/select-deluxe.html',
+    'templates/semantic-ui/inputTypes/select-deluxe/select-deluxe.js',
     'templates/semantic-ui/inputTypes/select-radio/select-radio.html',
     'templates/semantic-ui/inputTypes/select-radio/select-radio.js',
     'templates/semantic-ui/inputTypes/select-search/select-search.html',

--- a/templates/semantic-ui/inputTypes/select-deluxe/select-deluxe.html
+++ b/templates/semantic-ui/inputTypes/select-deluxe/select-deluxe.html
@@ -1,0 +1,28 @@
+<template name="afSelectDeluxe_semanticUI">
+  <div class="fluid field">
+    <div {{dropdownAtts}}>
+      <input type="hidden" {{inputAttsAdjust}}>
+      <i class="dropdown icon"></i>
+      <div class="default text">{{firstOption}}</div>
+      <div class="menu">
+        {{#each this.items}}
+          {{#if this.optgroup}}
+            <div class="header">{{this.optgroup}}</div>
+            {{#each this.items}}
+              <div {{itemAtts}}>
+                {{itemElementUpgrades}}
+                {{this.label}}
+              </div>
+            {{/each}}
+            <div class="divider"></div>
+          {{else}}
+            <div {{itemAtts}}>
+              {{itemElementUpgrades}}
+              {{this.label}}
+            </div>
+          {{/if}}
+        {{/each}}
+        </div>
+    </div>
+  </div>
+</template>

--- a/templates/semantic-ui/inputTypes/select-deluxe/select-deluxe.js
+++ b/templates/semantic-ui/inputTypes/select-deluxe/select-deluxe.js
@@ -1,0 +1,160 @@
+AutoForm.addInputType("select-deluxe", {
+  template: "afSelectDeluxe",
+  valueOut: function () {
+    return this.val();
+  },
+  valueConverters: {
+    "stringArray": function (val) {
+      if (typeof val === "string") {
+        val = val.split(",");
+        return _.map(val, function (item) {
+          return $.trim(item);
+        });
+      }
+      return val;
+    },
+    "number": AutoForm.Utility.stringToNumber,
+    "numberArray": function (val) {
+      if (typeof val === "string") {
+        val = val.split(",");
+        return _.map(val, function (item) {
+          item = $.trim(item);
+          return AutoForm.Utility.stringToNumber(item);
+        });
+      }
+      return val;
+    },
+    "boolean": AutoForm.Utility.stringToBool,
+    "booleanArray": function (val) {
+      if (typeof val === "string") {
+        val = val.split(",");
+        return _.map(val, function (item) {
+          item = $.trim(item);
+          return AutoForm.Utility.stringToBool(item);
+        });
+      }
+      return val;
+    },
+    "date": AutoForm.Utility.stringToDate,
+    "dateArray": function (val) {
+      if (typeof val === "string") {
+        val = val.split(",");
+        return _.map(val, function (item) {
+          item = $.trim(item);
+          return AutoForm.Utility.stringToDate(item);
+        });
+      }
+      return val;
+    }
+  },
+  contextAdjust: function (context) {
+    //can fix issues with some browsers selecting the firstOption instead of the selected option
+    context.atts.autocomplete = "off";
+
+    // build items list
+    context.items = [];
+
+    var itemAtts = function itemAtts(opt) {
+      var atts = { class: 'item', 'data-value': opt.value };
+      if ( context.atts.textOnlyWhenSelected ) {
+        atts['data-text'] = opt.label;
+      }
+      return atts;
+    };
+
+    // Add all defined options
+    _.each(context.selectOptions, function(opt) {
+      if (opt.optgroup) {
+        var subItems = _.map(opt.options, function(subOpt) {
+          return _.extend(subOpt, {
+            name: context.name,
+            itemAtts: itemAtts(subOpt),
+            atts: context.atts
+          });
+        });
+        context.items.push({
+          optgroup: opt.optgroup,
+          items: subItems
+        });
+      } else {
+        context.items.push(_.extend(opt, {
+          name: context.name,
+          itemAtts: itemAtts(opt),
+          atts: context.atts
+        }));
+      }
+    });
+
+    return context;
+  }
+});
+
+var capitalizeFirstLetter = function capitalizeFirstLetter(string) {
+    return string.charAt(0).toUpperCase() + string.slice(1);
+};
+
+var supportedItemUpgrades = {
+  'div': 'DIV',
+  'span': 'SPAN',
+  'icon': 'I',
+  'image': 'IMG'
+};
+
+Template.afSelectDeluxe_semanticUI.helpers({
+  inputAttsAdjust: function inputAttsAdjust() {
+    var atts = _.clone(this.atts);
+
+    delete atts.firstOption;
+    delete atts.withSearch;
+
+    _.each(supportedItemUpgrades, function (options, type) {
+      delete atts["with" + capitalizeFirstLetter(type)];
+    });
+
+    var currentData = Template.currentData();
+    if ( currentData ) atts.value = currentData.value;
+
+    return atts;
+  },
+  dropdownAtts: function () {
+    var atts = {
+      class: 'ui fluid selection dropdown'
+    };
+
+    // Add semantic-ui class
+    atts = AutoForm.Utility.addClass(atts, "search");
+
+    return atts;
+  },
+  firstOption: function () {
+    return typeof this.atts.firstOption === "string" ? this.atts.firstOption : "(Select One)";
+  },
+  itemElementUpgrades: function () {
+    var upgradeHtml = "";
+    _.each(supportedItemUpgrades, function (tag, type) {
+      if ( typeof this.atts['with' + capitalizeFirstLetter(type)] !== "undefined" ) {
+        var className = typeof this.atts['with' + capitalizeFirstLetter(type)] === "string" ? this.atts['with' + capitalizeFirstLetter(type)] : type + "Class";
+        if ( this[className] ) {
+          var elemContent, elemAttrs = { 'class': this[className] };
+          if ( type === "image" && this[type + "Src"] ) {
+            elemAttrs.src = this[type + "Src"];
+          } else if ( this[type + "Content"] ) {
+            elemContent = this[type + "Content"];
+          }
+
+          upgradeHtml += HTML.toHTML(HTML[tag](HTML.Attrs(elemAttrs), elemContent));
+        }
+      }
+    }, this);
+    return Spacebars.SafeString(upgradeHtml);
+  }
+});
+
+Template.afSelectDeluxe_semanticUI.onRendered(function() {
+  $(this.firstNode).find(".ui.dropdown").dropdown();
+
+  this.autorun(function () {
+    var dataContext = Template.currentData();
+    $(this.firstNode()).find(".ui.dropdown").dropdown('set selected', dataContext.value);
+  });
+});


### PR DESCRIPTION
I needed a dropdown that supported icons and option groups.  The .dropdown() wasn't automatically converting optgroups and it definitely wasn't supporting semantic icons, descriptions, labels, etc.

I'm not even sure if I would call this a 'select' anymore (and wasn't sure what to call the element- select-flex, dropdown-deluxe?  who knows), and these changes removed the `select` element entirely.  But what this does allow you to do is do a searchable dropdown with icons and all the other bells and whistles.  Let me try to show some examples here, for thought at least.
### Example

Not the best, but hopefully gets the idea across.
#### In Template

`{{> afQuickField name='country' type='select-deluxe' withSearch=true withSpan=true withIcon=true firstOption="(Select Country)" options=countryOptions}}`

You can also use `withDiv=true` and `withImage=true`.  If you pass something besides a boolean (i.e. `withIcon="myDatabaseFieldClass"` the passed-in string will be used as the key in the `options` lookup instead of the default `iconClass`.  Because I thought it was getting too complex, `span`, `div` and `image` content always have to be in `spanContent`, `divContent` and `imageSrc` respectively.

Of course, you can leave off `withSearch` to take away the search abilities.
#### In JavaScript (Autoform "options" Helper)

``` javascript
Template.registerHelper('countryOptions', function () {
    return [
      {
        optgroup: "Nordic Countries",
        options: Countries.find({code: { $in: ['fi','dk','is','se','no']}}).map(function (c) {
          return {label: c.name, iconClass: c.code + ' flag', spanClass: 'right floated description', spanContent: "Cold!", value: c.code};
        })
      },
      {
        optgroup: "Everyone Else",
        options: Countries.find({code: { $nin: ['fi','dk','is','se','no']}}).map(function (c) {
          return {label: c.name, iconClass: c.code + ' flag', value: c.code};
        })
      }
    ];
});
```
#### Screenshot

![Poor Zoomed Out Example](https://cloud.githubusercontent.com/assets/841294/7214973/3f123b9a-e5cb-11e4-9293-2e6a12963ea1.png)

I guess let me know about any thoughts you have.  I did get a little extreme in the template because it was so repetitive with the loops and made the `itemElementUpgrades` helper, but it seems okay.  A little less clear for making changes than having it in the template directly.
