### PR TITLE
Fix to prevent classes passed to autoForm and quickForm from getting overwritten.

### DIFF
--- a/templates/semantic-ui/semantic-ui.js
+++ b/templates/semantic-ui/semantic-ui.js
@@ -29,7 +29,7 @@ Template.autoForm.helpers({
       context.novalidate = "novalidate";
     }
 
-    context["class"] = "ui form";
+    context = AutoForm.Utility.addClass(context, "ui form");
 
     return _.omit(context,
       "schema",


### PR DESCRIPTION
Per [autoform documentation](/aldeed/meteor-autoform#component-and-helper-reference) about the quickForm and autoForm tags:

> Any additional attributes are passed along to the `<form>` element, meaning that you can add classes, etc. When providing a boolean attribute, set it to `true` (no quotation marks) or a helper that returns `true`.

This allows things like: `{{#>autoForm class="loading" schema=blah}}` to work properly.  Previous it was just forcing it to `ui form`.

Let me know if it looks okay.   Should be simple, but does effect everything. :)
