### PR TITLE
Add option to change Boolean (checkbox) type

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,26 @@ items = [
 ]
 ```
 
+### Boolean (checkbox) sub-types
+
+##### `checkbox` (default): A standard checkbox (see: [checkbox](http://semantic-ui.com/modules/checkbox.html#checkbox))
+
+```js
+{{> afQuickField name="isEnabled"}}
+```
+
+##### `slider`: A checkbox can be formatted to emphasize the current selection state (see: [slider](http://semantic-ui.com/modules/checkbox.html#slider))
+
+```js
+{{> afQuickField name="isEnabled" checkbox-type="slider"}}
+```
+
+##### `toggle`: A checkbox can be formatted to show an on or off choice (see: [toggle](http://semantic-ui.com/modules/checkbox.html#toggle))
+
+```js
+{{> afQuickField name="isEnabled" checkbox-type="toggle"}}
+```
+
 ## Options
 
 #### Show errors in label

--- a/templates/semantic-ui/inputTypes/boolean-checkbox/boolean-checkbox.html
+++ b/templates/semantic-ui/inputTypes/boolean-checkbox/boolean-checkbox.html
@@ -1,6 +1,6 @@
 <template name="afCheckbox_semanticUI">
-  <div class="ui checkbox">
-    <input type="checkbox" value="{{this.value}}" {{atts}} />
+  <div class="ui {{checkboxType}}checkbox">
+    <input type="checkbox" value="{{this.value}}" {{itemAtts}} />
     <label>{{afFieldLabelText name=this.name}}</label>
   </div>
 </template>

--- a/templates/semantic-ui/inputTypes/boolean-checkbox/boolean-checkbox.js
+++ b/templates/semantic-ui/inputTypes/boolean-checkbox/boolean-checkbox.js
@@ -1,3 +1,23 @@
 Template.afCheckbox_semanticUI.onRendered(function() {
   $(this.firstNode).checkbox();
 });
+
+Template.afCheckbox_semanticUI.helpers({
+  /*
+    Adds option to change checkbox type
+    Options are:
+      checkbox (default)
+      slider   (http://semantic-ui.com/modules/checkbox.html#slider)
+      toggle   (http://semantic-ui.com/modules/checkbox.html#toggle)
+  */
+  checkboxType: function () {
+    switch (this.atts["checkbox-type"]) {
+      case "slider": return "slider ";
+      case "toggle": return "toggle ";
+      default: return;
+    }
+  },
+  itemAtts: function () {
+    return _.omit(this.atts, "checkbox-type")
+  }
+});


### PR DESCRIPTION
Adds option to change checkbox type.

Options are:
- checkbox (default)
- [slider](http://semantic-ui.com/modules/checkbox.html#slider)
- [toggle](http://semantic-ui.com/modules/checkbox.html#toggle)
