### PR TITLE
Add the possibility to set attrs on the formgroup & label

### DIFF
--- a/templates/semantic-ui/components/afFormGroup/afFormGroup.html
+++ b/templates/semantic-ui/components/afFormGroup/afFormGroup.html
@@ -1,5 +1,5 @@
 <template name="afFormGroup_semanticUI">
-  <div class="field {{afFormGroupClass}} {{required}}{{#if afFieldIsInvalid name=this.name}} error{{/if}}" {{afFormGroupAtts}}>
+  <div class="{{afFormGroupClass}} field {{required}}{{#if afFieldIsInvalid name=this.name}} error{{/if}}" {{afFormGroupAtts}}>
     {{#unless skipLabel}}
       <label {{afFieldLabelAtts}}>
         {{#if this.labelText}}

--- a/templates/semantic-ui/components/afFormGroup/afFormGroup.html
+++ b/templates/semantic-ui/components/afFormGroup/afFormGroup.html
@@ -1,7 +1,7 @@
 <template name="afFormGroup_semanticUI">
-  <div class="field {{required}}{{#if afFieldIsInvalid name=this.name}} error{{/if}}">
+  <div class="field {{afFormGroupClass}} {{required}}{{#if afFieldIsInvalid name=this.name}} error{{/if}}" {{afFormGroupAtts}}>
     {{#unless skipLabel}}
-      <label>
+      <label {{afFieldLabelAtts}}>
         {{#if this.labelText}}
           {{this.labelText}}
         {{else}}


### PR DESCRIPTION
This is now possible thanks to changes in meteor-autoform.  Any
attrs prefixed with formgroup- will be added to the containing div
and any prefixed with label- will be added to the label for the field.

See https://github.com/aldeed/meteor-autoform/commit/22ee3b00295bfffb30629bad036411b313f1a439
the docs at https://github.com/aldeed/meteor-autoform#afformgroup for
more information.
