### PR TITLE
For a consistent experience, close the dropdown after erasing.

### DIFF
--- a/templates/semantic-ui/inputTypes/select/select.js
+++ b/templates/semantic-ui/inputTypes/select/select.js
@@ -151,7 +151,7 @@ Template.afSelect_semanticUI.helpers({
 
 Template.afSelect_semanticUI.events({
 	"click .ui.clear.button": function(event) {
-		$(event.target).closest(".ui.dropdown").dropdown("clear");
+		$(event.target).closest(".ui.dropdown").dropdown("clear").dropdown("hide");
 	}
 });
 


### PR DESCRIPTION
It seems that closing the dropdown box when clicking the eraser icon
should be the normal experience, just as if you selected a normal
option.  Previously, it just sat there and you had to click off of it.
