### PR TITLE
Remove "field" class wrap since it's already included in afFormGroup

### DIFF
--- a/templates/semantic-ui/inputTypes/basic-select/basic-select.html
+++ b/templates/semantic-ui/inputTypes/basic-select/basic-select.html
@@ -1,17 +1,15 @@
 <template name="afBasicSelect_semanticUI">
-  <div class="fluid field">
-    <select {{atts}}>
-      {{#each this.items}}
-        {{#if this.optgroup}}
-          <optgroup label="{{this.optgroup}}">
-            {{#each this.items}}
-              <option {{afSelectOptionAtts}}>{{this.label}}</option>
-            {{/each}}
-          </optgroup>
-        {{else}}
-          <option {{afSelectOptionAtts}}>{{this.label}}</option>
-        {{/if}}
-      {{/each}}
-    </select>
-  </div>
+  <select {{atts}}>
+    {{#each this.items}}
+      {{#if this.optgroup}}
+        <optgroup label="{{this.optgroup}}">
+          {{#each this.items}}
+            <option {{afSelectOptionAtts}}>{{this.label}}</option>
+          {{/each}}
+        </optgroup>
+      {{else}}
+        <option {{afSelectOptionAtts}}>{{this.label}}</option>
+      {{/if}}
+    {{/each}}
+  </select>
 </template>

--- a/templates/semantic-ui/inputTypes/select/select.html
+++ b/templates/semantic-ui/inputTypes/select/select.html
@@ -1,38 +1,36 @@
 <template name="afSelect_semanticUI">
-  <div class="fluid field">
-    <div {{divAtts}}>
-      <input type="hidden" {{this.atts}} value="{{this.value}}">
-      {{#if this.value}}
-        <div class="text">{{label}}</div>
-      {{else}}
-        <div class="default text">{{placeholder}}</div>
-      {{/if}}
-      <i class="dropdown icon"></i>
-      <div class="menu">
-        {{#unless required}}
-          <div class="ui fluid compact clear button"><i class="erase icon"></i></div>
-        {{/unless}}
-        {{#each this.items}}
-          {{#if this.itemGroup}}
-            <div class="header">{{this.itemGroup}}</div>
-            {{#each this.items}}
-              <div {{itemHtmlAtts}} data-value="{{this.value}}">
-                {{#if this.icon}}
-                  <i class="{{this.icon}}"></i>
-                {{/if}}
-                {{this.label}}
-              </div>
-            {{/each}}
-          {{else}}
+  <div {{divAtts}}>
+    <input type="hidden" {{this.atts}} value="{{this.value}}">
+    {{#if this.value}}
+      <div class="text">{{label}}</div>
+    {{else}}
+      <div class="default text">{{placeholder}}</div>
+    {{/if}}
+    <i class="dropdown icon"></i>
+    <div class="menu">
+      {{#unless required}}
+        <div class="ui fluid compact clear button"><i class="erase icon"></i></div>
+      {{/unless}}
+      {{#each this.items}}
+        {{#if this.itemGroup}}
+          <div class="header">{{this.itemGroup}}</div>
+          {{#each this.items}}
             <div {{itemHtmlAtts}} data-value="{{this.value}}">
               {{#if this.icon}}
                 <i class="{{this.icon}}"></i>
               {{/if}}
               {{this.label}}
             </div>
-          {{/if}}
-        {{/each}}
-      </div>
+          {{/each}}
+        {{else}}
+          <div {{itemHtmlAtts}} data-value="{{this.value}}">
+            {{#if this.icon}}
+              <i class="{{this.icon}}"></i>
+            {{/if}}
+            {{this.label}}
+          </div>
+        {{/if}}
+      {{/each}}
     </div>
   </div>
 </template>

--- a/templates/semantic-ui/inputTypes/select/select.js
+++ b/templates/semantic-ui/inputTypes/select/select.js
@@ -156,7 +156,7 @@ Template.afSelect_semanticUI.events({
 });
 
 Template.afSelect_semanticUI.onRendered(function() {
-  $(this.firstNode).find(".ui.dropdown").dropdown({
+  $(this.firstNode).dropdown({
 		fullTextSearch: this.data.atts.fullTextSearch || false
 	});
 });


### PR DESCRIPTION
Curious what the thoughts are about this.  Currently, the `basic-select` and the `select` both wrap the element in a `fluid field`.  However, `afFormGroup` already wraps these elements with it's own `field`, thus the `field` class is doubled up.  This has caused me to have weird `margin-bottom` padding when I have stacked rows of fields, as in:

``` html
      <!-- First two fields are select OR basic-select -->
      <div class="three fields">
        {{> afQuickField name="type"}
        {{> afQuickField name="timezone"}}
        {{> afQuickField name="count"}} <!-- number -->
      </div>
      <div class="two fields">
        {{> afQuickField name="username"}} <!-- text -->
        {{> afQuickField name="birthday"}} <!-- date -->
      </div>
```

With this pull-request, the issue is fixed for me on `select` and `basic-select`.  This doesn't solve any similar additional wrapping that might be happening in `select-checkbox` or `select-radio`, but I'm not sure if this currently causes any problems since I don't have any use-cases for those components.

Thoughts?  I'm not sure if the `fluid field` is actually accomplishing anything right now as it is.
