### PR TITLE
Change red corner label size from small to mini

### DIFF
--- a/templates/semantic-ui/components/afArrayField/afArrayField.html
+++ b/templates/semantic-ui/components/afArrayField/afArrayField.html
@@ -12,7 +12,7 @@
       <div class="field autoform-array-item">
         <div class="ui input">
           {{#if afArrayFieldHasMoreThanMinimum name=../atts.name minCount=../atts.minCount maxCount=../atts.maxCount}}
-            <div class="ui small red corner label autoform-remove-item">
+            <div class="ui mini red corner label autoform-remove-item">
               <i class="icon minus"></i>
             </div>
           {{/if}}


### PR DESCRIPTION
Change `red corner label` size from `small` to `mini`. SemanticUI 2.0 has done something with the sizes so the original red corner label was way oversized. `tiny` was still too big, so chose `mini` (smallest).

![image](https://cloud.githubusercontent.com/assets/7933750/8647910/79250040-295c-11e5-840a-3fe545c24075.png)
