### PR TITLE
Clear placeholder fix

### DIFF
--- a/templates/semantic-ui/inputTypes/select/select.html
+++ b/templates/semantic-ui/inputTypes/select/select.html
@@ -2,11 +2,7 @@
   <div class="fluid field">
     <div {{divAtts}}>
       <input type="hidden" {{this.atts}} value="{{this.value}}">
-      {{#if this.value}}
-        <div class="text">{{label}}</div>
-      {{else}}
-        <div class="default text">{{placeholder}}</div>
-      {{/if}}
+      <div class="default text">{{placeholder}}</div>
       <i class="dropdown icon"></i>
       <div class="menu">
         {{#unless required}}

--- a/templates/semantic-ui/inputTypes/select/select.js
+++ b/templates/semantic-ui/inputTypes/select/select.js
@@ -126,14 +126,6 @@ Template.afSelect_semanticUI.helpers({
 	placeholder: function() {
 		return this.atts.placeholder || "(Select One)";
 	},
-	label: function() {
-		var value       = this.value;
-		var currentItem = _.find(this.items, function(item) {
-			return item.value === value;
-		});
-
-		return currentItem.label;
-	},
 	required: function() {
 		return this.atts.required === "";
 	},


### PR DESCRIPTION
The placeholder text should return when clearing an optional field that had an existing value.

Straight out of the box, when Clearing an Optional Field, if the form was an "insert" it was properly cleared when using the clear button, however, if it was an "update" and had a value already, the placeholder was not properly returned to it's placeholder state (i.e. "Select One").  The input value WAS being updated, but the display text for the select was left as the previous value.  This seems to fix it.

Also, the `label` stuff seems to be taken care of by Semantic automatically hence the `label` helper seems redundant.  Am I missing something?  Give me a quick peer review if you get a chance.  :)
