### PR TITLE
Allow the "class" to be passed through to the UI Dropdown

### DIFF
--- a/templates/semantic-ui/inputTypes/select/select.html
+++ b/templates/semantic-ui/inputTypes/select/select.html
@@ -1,6 +1,6 @@
 <template name="afSelect_semanticUI">
   <div {{divAtts}}>
-    <input type="hidden" {{this.atts}} value="{{this.value}}">
+    <input type="hidden" {{inputAtts}} value="{{this.value}}">
     <div class="default text">{{placeholder}}</div>
     <i class="dropdown icon"></i>
     <div class="menu">

--- a/templates/semantic-ui/inputTypes/select/select.js
+++ b/templates/semantic-ui/inputTypes/select/select.js
@@ -74,7 +74,9 @@ AutoForm.addInputType("select", {
 
 Template.afSelect_semanticUI.helpers({
 	divAtts() {
-		let atts = { class: "ui dropdown" };
+		let atts = _.pick(this.atts, "class");
+
+		atts = AutoForm.Utility.addClass(atts, "ui dropdown");
 
 		// Add selection class
 		if (this.atts.selection) {
@@ -92,6 +94,9 @@ Template.afSelect_semanticUI.helpers({
 		}
 
 		return atts;
+	},
+	inputAtts() {
+		return _.omit(this.atts, "class");
 	},
 	placeholder() {
 		return this.atts.placeholder || "(Select One)";


### PR DESCRIPTION
I guess this is another similar issue to the `selection` previously mentioned.  With the recent removal of `fluid` from the dropdown classes, I now have fields that are overlapping that weren't before.

<img width="404" alt="screen shot 2015-09-28 at 5 25 51 pm" src="https://cloud.githubusercontent.com/assets/841294/10138672/4da58078-6608-11e5-89c2-dcab52ec28e7.png">

Adding `fluid` fixes it and so does `compact`.  However, now it's a situation where everything is a different flag to pass (i.e. `selection=true`, `fluid=true`, `floating=true`, etc.).  I thought it would be better to use `class` that is passed to the `afQuickField` and apply it to the `ui dropdown`.  Since normally, this is passed to the hidden input, the class doesn't really matter.

Now, you could get rid of the `selection=true` feature that was just added and just suggest adding `class="selection"`, which might be the better way to do it?  Either way, I think this is a good feature that more closely copies what you would expect when passing `class` to a `afQuickField`.

Here is my commit message... 

This allows the passing of things like `compact`, `fluid`, or `floated` through
to the UI Dropdown containing DIV element by simply passing `class=blah` on the
`afQuickField`.  Normally the `class` would be passed through to the `input`
(which is `type="hidden"` and doesn't need `class`), but this provides
the option to use the more complete scope of `ui dropdown` options.

Also, since the removal of the hardcoded `fluid` class in 0.6.1, this is
sometimes necessary so you can do `class="fluid"`.
